### PR TITLE
Remove namespace

### DIFF
--- a/src/RestBundle/Controller/RestDataObjectRead.php
+++ b/src/RestBundle/Controller/RestDataObjectRead.php
@@ -26,7 +26,7 @@ trait RestDataObjectRead
 
     protected function getClass()
     {
-        return "\\Pimcore\\Model\\DataObject\\{$this->getClassName()}";
+        return $this->getClassName();
     }
 
     /**
@@ -72,7 +72,7 @@ trait RestDataObjectRead
     {
         $filters = $this->getListFilters();
 
-        $listClass = "\\Pimcore\\Model\\DataObject\\{$this->getClassName()}";
+        $listClass = $this->getClassName();
 
         if (!class_exists($listClass)) {
             throw new \InvalidArgumentException("Invalid class name given. {$listClass}");


### PR DESCRIPTION
Do not add the namespace to the class name, so that one can use `<myDataObject>::class` as class name. Right now, the following code will throw an exception when visiting `http://localhost.my-app.com/api/v1/players` (assuming that a `DataObject `of type `Player `exists).

**/AppBundle/Controller/PlayerApiController.php**
```
<?php

namespace AppBundle\Controller;

use DavesWeblab\RestBundle\Controller\RestDataObjectRead;
use Pimcore\Model\DataObject\Player;
use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;

/**
 * Class PlayerApiController
 * @package src\AppBundle\Controller
 *
 * @Route("/api/v1/players")
 */
class PlayerApiController
{
    use RestDataObjectRead;

    /**
     * @return string
     */
    protected function getClassName()
    {
        return Player::class;
    }
}
```