### PR TITLE
Updated object reader to use the fully qualified namespace rather than the name of the class only

### DIFF
--- a/src/RestBundle/Controller/RestDataObjectRead.php
+++ b/src/RestBundle/Controller/RestDataObjectRead.php
@@ -8,15 +8,21 @@ use DavesWeblab\RestBundle\Rest\DataObject\Read\ListPaginationFilter;
 use DavesWeblab\RestBundle\Serializer\Serializer;
 use Pimcore\Model\DataObject\ClassDefinition;
 use Pimcore\Model\Listing\AbstractListing;
+use DavesWeblab\RestBundle\Exception\InvalidNamespaceException;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
 use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Pimcore\Model\DataObject;
+use Pimcore\Model\DataObject\AbstractObject;
 
 trait RestDataObjectRead
 {
     /**
-     * @return string
+     * To avoid any InvalidNamespaceException's, create a new model class (e.g. MyModel) and extend from
+     * the AbstractObject class. Afterwards, return MyModel::class.
+     *
+     * @return string the class (including its namespace) that is to be used as model.
      */
     abstract protected function getClassName();
 
@@ -24,13 +30,17 @@ trait RestDataObjectRead
     {
     }
 
+    /**
+     * Alias for this#getClassName().
+     * @return string
+     */
     protected function getClass()
     {
-        return "\\Pimcore\\Model\\DataObject\\{$this->getClassName()}";
+        return $this->getClassName();
     }
 
     /**
-     * @return ClassDefinition
+     * @return ClassDefinition|null null is returned if an error occurred.
      */
     protected function getClassDefinition()
     {
@@ -70,22 +80,12 @@ trait RestDataObjectRead
      */
     public function listAction(Serializer $serializer, Request $request)
     {
+        $this->assertClass();
+
+        $listClass = $this->getClassName();
+        $list = $listClass::getList();
+
         $filters = $this->getListFilters();
-
-        $listClass = "\\Pimcore\\Model\\DataObject\\{$this->getClassName()}";
-
-        if (!class_exists($listClass)) {
-            throw new \InvalidArgumentException("Invalid class name given. {$listClass}");
-        }
-
-        try {
-            /**
-             * @var AbstractListing $list
-             */
-            $list = $listClass::getList();
-        } catch (\Exception $e) {
-            throw new \InvalidArgumentException("Invalid object class given. {$listClass}::getList");
-        }
 
         foreach ($filters as $filter) {
             $filter->apply($request, $list);
@@ -100,8 +100,9 @@ trait RestDataObjectRead
      */
     public function getAction($id, Serializer $serializer, Request $request)
     {
-        $className = $this->getClass();
+        $this->assertClass();
 
+        $className = $this->getClass();
         try {
             $object = $className::getById($id);
 
@@ -127,5 +128,50 @@ trait RestDataObjectRead
     public function optionsAction()
     {
         return new Response("OK");
+    }
+
+    /**
+     * @return string the valid namespace. This will be used to check against the given classes namespace.
+     */
+    private function getValidClass()
+    {
+        return AbstractObject::class;
+    }
+
+    /**
+     * Asserts the class that was set by the user.
+     */
+    private function assertClass()
+    {
+        $className = $this->getClass();
+
+        $this->assertClassExistence($className);
+        $this->assertNamespace($className);
+    }
+
+    /**
+     * Asserts the existence of the class name.
+     *
+     * @param string $className the class name that was set by the user
+     * @throws InvalidNamespaceException if the class does not exist.
+     */
+    private function assertClassExistence($className)
+    {
+        if (!class_exists($className)) {
+            throw new InvalidNamespaceException($this->getValidClass());
+        }
+    }
+
+    /**
+     * Asserts the namepsace of the class name. Call this#assertClassExistence() beforehand, to ensure the class exists.
+     *
+     * @param string $className the class name that was set by the user
+     * @throws InvalidNamespaceException if the class is not within a valid namespace.
+     */
+    private function assertNamespace($className)
+    {
+        if(!is_a($className, $this->getValidClass(), true)){
+            throw new InvalidNamespaceException($this->getValidClass());
+        }
     }
 }

--- a/src/RestBundle/Exception/InvalidNamespaceException.php
+++ b/src/RestBundle/Exception/InvalidNamespaceException.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace DavesWeblab\RestBundle\Exception;
+
+use Exception;
+
+/**
+ * Class InvalidNamespaceException
+ * @package RestBundle\Exception
+ *
+ * Exception thrown to indicate an invalid namespace, detected during runtime.
+ */
+class InvalidNamespaceException extends \RuntimeException
+{
+    const DEFAULT_MESSAGE = "The given namespace is invalid.";
+
+    /** @var string $validNamespace the valid namespace to display to the user */
+    private $validNamespace;
+
+    /**
+     * InvalidNamespaceException constructor.
+     *
+     * @param string $validNamespace the valid namespace to display to the user
+     * @inheritdoc
+     */
+    public function __construct(string $validNamespace, $message = "", $code = 0, Exception $previous = null)
+    {
+        $this->validNamespace = $validNamespace;
+        $message = $this->computeMessage($message);
+        parent::__construct($message, $code, $previous);
+    }
+
+    /**
+     * @param string $message the message to use instead of self::DEFAULT_MESSAGE
+     * @return string the default message to display to the user.
+     */
+    private function computeMessage($message)
+    {
+        $message = $message ?: self::DEFAULT_MESSAGE;
+        return "$message You can only use objects of type $this->validNamespace";
+    }
+}


### PR DESCRIPTION
## Why change?
By doing so, it is possible to keep the namespace restriction, while avoiding harcoded strings as class name. Furthermore, [IDEs](https://en.wikipedia.org/wiki/Integrated_development_environment) like [PHPStorm ](https://www.jetbrains.com/phpstorm/specials/phpstorm/phpstorm.html?gclid=CjwKCAjwrqnYBRB-EiwAthnBFlDszKQC58mYIUdV6jdYzqP0oR_3Ynlz4hPZyIqgoGhETqyWwnVSpxoCQuwQAvD_BwE&gclsrc=aw.ds.ds&dclid=CMLM_9nLpdsCFZSNGwodXwoAcw) can now jump to the specified class, using the corresponding shortcuts.

## Usage
Basically, the usage does not differ much, only the namespace needs to be provided. This means that either `MyModel::class` or `"\Namespace\To\MyModel"` can be used instead of `"MyModel"` only.
While the latter seems to be of disadvantage as it requires additional information passed by the user, the former is the intended way to go. Not only because of the aforementioned reasons, but also because the code has increased readability and maintainability.

```
/**
 * @inheritdoc
 */
protected function getClassName()
{
    return MyModel::class;
}
```

## Additional Information
A proper exception was added to notify the programmer about invalid classes in use.